### PR TITLE
Move to PostCSS 5.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - iojs
   - "0.12"
-  - "0.10"

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = function (opts) {
     return function (css) {
 
       // for each rules, each decl
-      css.eachRule(function (rule) {
-        rule.eachDecl(function (decl, i) {
+      css.walkRules(function (rule) {
+        rule.walkDecls(function (decl, i) {
 
           if (decl.value.indexOf('vmin') === -1) { return; }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url":  "https://github.com/iamvdo/postcss-vmin.git"
     },
     "dependencies": {
-        "postcss": "^4.0.3"
+        "postcss": "^5.0.0"
     },
     "devDependencies": {
         "jshint-stylish": "1.0.0",


### PR DESCRIPTION
PostCSS 5.0 API has breaking changes (mainly with `each*` -> `walk*`), so if you merge this you’ll want to bump a major version for the npm module :-)
